### PR TITLE
Segments of arrows specified in a var

### DIFF
--- a/js/vibcrystal.js
+++ b/js/vibcrystal.js
@@ -55,6 +55,7 @@ class VibCrystal {
         this.arrowHeadLengthRatio = .25;
         this.arrowRadius = 0.1;
         this.arrowLength = 1.0;
+        this.arrowSegments = 8;
 
         //arrowscale
         this.arrowScale = 2.0;
@@ -423,10 +424,12 @@ class VibCrystal {
             //arrow geometry
             let arrowGeometry = new THREE.CylinderGeometry( 0, 
                                                             this.arrowHeadRadiusRatio*this.arrowRadius, 
-                                                            this.arrowLength*this.arrowHeadLengthRatio );
+                                                            this.arrowLength*this.arrowHeadLengthRatio,
+                                                            this.arrowSegments );
 
             let axisGeometry  = new THREE.CylinderGeometry( this.arrowRadius, this.arrowRadius, 
-                                                            this.arrowLength );
+                                                            this.arrowLength,
+                                                            this.arrowSegments );
 
             let AxisMaterial  = new THREE.MeshLambertMaterial( { color: this.arrowcolor, 
                                                                  blending: THREE.AdditiveBlending } );


### PR DESCRIPTION
This commit makes the number of arrow segments adjustable just like you did with bondSegments.
The value is set to 8 which was the default already.

Just like in the Vesta/JMOL choice we didn't add any slider to change this setting,
so that you can decide if and where it should be placed

On request of Jonas Bekaert (UA) we are already hosting this locally with a setting of 20.
The reason would be that it looks better in publications.
