### PR TITLE
ibrav = -5 option added to pw.py

### DIFF
--- a/phononweb/pw.py
+++ b/phononweb/pw.py
@@ -231,6 +231,18 @@ class PwIn():
             self.cell_parameters = [[   a,          0,  0],
                                     [-a/2,sqrt(3)/2*a,  0],
                                     [   0,          0,c*a]]
+        elif ibrav == -5:
+            a = float(self.system['celldm(1)'])
+            c = float(self.system['celldm(4)'])
+            tx = sqrt((1.0-c)/2.0)
+            ty = sqrt((1.0-c)/6.0)
+            tz = sqrt((1.0+2.0*c)/3.0)
+            u = tz - 2.0*sqrt(2.0)*ty
+            v = tz + sqrt(2.0)*ty
+            aa = a/sqrt(3.0)	    
+            self.cell_parameters = [[aa*u, aa*v, aa*v],
+                                    [aa*v, aa*u, aa*v],
+                                    [aa*v, aa*v, aa*u]]
         elif ibrav == 6:
             a = float(self.system['celldm(1)'])
             c = float(self.system['celldm(3)'])


### PR DESCRIPTION
When trying to create .json files from a QE structure with ibrav = -5, I got the error message "ibrav = -5 is not implemented". I solved this issue by implementing ibrav = -5 in pw.py file. This pull request is to update your repository with this new option implemented so that new users who clone your repository get the new function. 