### PR TITLE
Fix Regex Syntax in slicefile method to Prevent re.error

### DIFF
--- a/phononweb/pw.py
+++ b/phononweb/pw.py
@@ -279,7 +279,7 @@ class PwIn():
                         exit()
 
     def slicefile(self, keyword):
-        lines = re.findall('&(?i)%s(?:.?)+\n((?:.+\n)+?)(?:\s+)?[\/&]'%keyword,"".join(self.file_lines),re.MULTILINE)
+        lines = re.findall(r'(?i)&%s(?:.?)+\n((?:.+\n)+?)(?:\s+)?[\/&]' % keyword, "".join(self.file_lines), re.MULTILINE)
         return lines
 
     def store(self,group,name):


### PR DESCRIPTION
This PR fixes a bug in the `slicefile` method of the `pw.py` module, which was causing the following error when running `read_qe_phonon.py`:

```
re.error: global flags not at the start of the expression
```

#### **Issue**
The regex pattern in the `slicefile` method was incorrectly using the case-insensitivity flag `(?i)` inside the pattern instead of at the start. Python requires global flags like `(?i)` to appear at the very beginning of the regex. Without this fix, the program raises a `re.error`.

#### **Fix**
Updated the regex pattern in `pw.py`:
   ```python
# From
   lines = re.findall('&(?i)%s(?:.?)+\n((?:.+\n)+?)(?:\s+)?[\/&]' % keyword, "".join(self.file_lines), re.MULTILINE)
# To
lines = re.findall(r'(?i)&%s(?:.?)+\n((?:.+\n)+?)(?:\s+)?[\/&]' % keyword, "".join(self.file_lines), re.MULTILINE)
```
